### PR TITLE
Allow setting pixel character for higher resolution.

### DIFF
--- a/bin/tube.js
+++ b/bin/tube.js
@@ -3,6 +3,7 @@ var argv = require('optimist')
     .usage('Usage: picture-tube OPTIONS { file or uri }')
     .demand(1)
     .describe('cols', 'number of columns to use for output')
+    .describe('char', 'character to use for rendering pixels')
     .argv
 ;
 var tube = require('../')(argv);

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ var Stream = require('stream').Stream;
 module.exports = function (opts) {
     if (!opts) opts = {};
     if (!opts.cols) opts.cols = 80;
+    if (!opts.char) opts.char = '';
     
     var c = charm();
     var bufs = buffers();
@@ -21,13 +22,36 @@ module.exports = function (opts) {
             var dx = png.width / opts.cols;
             var dy = 2 * dx;
             
+            function index(x, y) {
+                return (Math.floor(y) * png.width + Math.floor(x)) * 4;
+            }
+
+            function rgb(i) {
+                return [pixels[i], pixels[i+1], pixels[i+2]];
+            }
+
+            function alpha(i) {
+                return pixels[i+3];
+            }
+
+            var render;
+            if (opts.char === '') {
+                render = function(top, bottom) {
+                    c.background(top).write(' ');
+                };
+            }
+            else {
+                render = function(top, bottom) {
+                    c.foreground(top).background(bottom).write(opts.char);
+                };
+            }
+
             for (var y = 0; y < png.height; y += dy) {
                 for (var x = 0; x < png.width; x += dx) {
-                    var i = (Math.floor(y) * png.width + Math.floor(x)) * 4;
-                    
-                    var ix = x256([ pixels[i], pixels[i+1], pixels[i+2] ]);
-                    if (pixels[i+3] > 0) {
-                        c.background(ix).write(' ');
+                    var top = x256(rgb(index(x, y)));
+                    var bottom = x256(rgb(index(x, y + 1)));
+                    if (alpha(top) > 0 && alpha(bottom) > 0) {
+                        render(top, bottom);
                     }
                     else {
                         c.display('reset').write(' ');


### PR DESCRIPTION
This adds a `--char` option, which allows setting the character used for rendering pixels. If you set it to `U+2580 UPPER HALF BLOCK` or `U+2591 LIGHT SHADE`, you get a higher apparent vertical resolution. Unfortunately, many terminal emulators render these characters with artifacts, so the default is still the lower-resolution version.