### PR TITLE
Update dep to patch security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "charm" : "~0.1.0",
         "png-js" : "~0.1.0",
         "x256" : "~0.0.1",
-        "request" : "~2.9.202",
+        "request" : "~2.83.0",
         "optimist" : "~0.3.4"
     },
     "devDependencies" : {


### PR DESCRIPTION
Patch `request` due to Remote Memory Exposure vulnerability: https://nodesecurity.io/advisories/309
Later versions used a vulnerable version of the `tough-cookie` transitive dep which was upgraded in `request` v2.83.0.

Suggesting the patch mainly to relieve stress in upstream projects that run security scanners like NSP or Snyk that are alerting on this dep without consideration for picture-tube's usage of it.